### PR TITLE
fix:  add default value for user.groups

### DIFF
--- a/common.js
+++ b/common.js
@@ -109,7 +109,8 @@ Schema.Users = new SimpleSchema({
     },
     groups: {
         type: [String],
-        label: "Groups for this user"
+        label: "Groups for this user",
+        defaultValue: []
     }
 });
 


### PR DESCRIPTION
Set user.groups to [] if not specified to ensure user has groups.

All tests pass.
