### PR TITLE
feat:  remove unneeded css references from main page

### DIFF
--- a/client/OpenClicker.html
+++ b/client/OpenClicker.html
@@ -1,21 +1,6 @@
 <head>
   <title>Open Clicker</title>
-  <base href="/">
-  
-  <!-- Styles -->
-  <!-- Bootstrap CSS -->
-  <link href="css/bootstrap.min.css" rel="stylesheet">
-  <!-- jQuery Datatables -->
-  <link href="css/jquery.dataTables.css" rel="stylesheet">
-  <!-- Font awesome CSS -->
-  <link href="css/font-awesome.min.css" rel="stylesheet">		
-  <!-- jQuery gritter -->
-  <link href="css/jquery.gritter.css" rel="stylesheet">
-  <!-- Custom Color CSS -->
-  <link href="css/less-style.css" rel="stylesheet">	
-  <!-- Custom CSS -->
-  <link href="css/style.css" rel="stylesheet">
-  <link href="css/OpenClicker.css" rel="stylesheet">
+  <base href="/"> 
 </head>
 
 <body ng-app="openClicker" ng-strict-di="">


### PR DESCRIPTION
Remove CSS reference tags from the main page since meteor
includes the CSS files on its own.

All tests pass.

Closes #58.
