### PR TITLE
feat:  add active questions view

### DIFF
--- a/client/controllers/activeQuestionsCtrl.js
+++ b/client/controllers/activeQuestionsCtrl.js
@@ -1,0 +1,15 @@
+(function () {
+  'use-strict';
+  
+  angular
+    .module('openClicker')
+    .controller('activeQuestionsCtrl', activeQuestionsCtrl);
+    
+  activeQuestionsCtrl.$inject = ['$stateParams'];
+  
+  function activeQuestionsCtrl($stateParams) {
+    var vm = this;
+
+    vm.groupId = $stateParams.groupId;
+  }
+})();

--- a/client/directives/controllers/ocActiveQuestionsCtrl.js
+++ b/client/directives/controllers/ocActiveQuestionsCtrl.js
@@ -1,0 +1,26 @@
+(function () {
+  'use-strict';
+  
+  angular
+    .module('openClicker')
+    .controller('ocActiveQuestionsCtrl', ocActiveQuestionsCtrl);
+    
+  ocActiveQuestionsCtrl.$inject = ['$scope', '$reactive'];
+  
+  function ocActiveQuestionsCtrl($scope, $reactive) {
+    var vm = this;
+    $reactive(vm).attach($scope);
+    
+    vm.subscribe('activeQuestions');
+    vm.subscribe('joinedGroups');
+    
+    vm.helpers({
+      questions: () => Questions.find({
+        groupId: vm.groupId
+      }),
+      group: () => Groups.findOne({
+        _id: vm.groupId
+      })
+    });
+  }
+})();

--- a/client/directives/controllers/ocGroupsCtrl.js
+++ b/client/directives/controllers/ocGroupsCtrl.js
@@ -13,14 +13,10 @@
     
     vm.groups = [];
     
-    vm.subscribe('groups');
+    vm.subscribe('joinedGroups');
     
     vm.helpers({
-      groups: () => Groups.find({
-        _id: {
-          $in : Meteor.user().groups
-        },
-      }),
+      groups: () => Groups.find({}),
       userID: () => {
         return Meteor.userId();
       },

--- a/client/directives/ocActiveQuestions.js
+++ b/client/directives/ocActiveQuestions.js
@@ -1,0 +1,24 @@
+(function () {
+  'use strict';
+  
+  angular
+    .module('openClicker')
+    .directive('ocActiveQuestions', ocActiveQuestions);
+    
+  ocActiveQuestions.$inject = [];
+  
+  function ocActiveQuestions() {
+    var directive = {
+      controller: 'ocActiveQuestionsCtrl',
+      controllerAs: 'vm',
+      templateUrl: 'client/templates/directives/ocActiveQuestions.html',
+      restrict: 'E',
+      scope: {
+        groupId: '@'
+      },
+      bindToController: true
+    };
+    
+    return directive;
+  }
+})();

--- a/client/lib/_config/routing.js
+++ b/client/lib/_config/routing.js
@@ -6,6 +6,29 @@
     
     // Define states
     $stateProvider
+      .state('activeQuestions', {
+        url: '/active-questions/:groupId',
+        views: {
+          header: {
+            templateUrl: 'client/templates/header.html'
+          },
+          main: {
+            templateUrl: 'client/templates/routes/activeQuestions.html'
+          }    
+        },
+        data: {
+          rule: function () {
+            if (!Meteor.userId() ||
+                !Meteor.user().emails[0].verified)
+            {
+              return {
+                to: 'home',
+                params: {}
+              }
+            }
+          }
+        }
+      })
       .state('answerQuestion', {
         url: '/answer-question/:questionId',
         views: {

--- a/client/templates/directives/ocActiveQuestions.html
+++ b/client/templates/directives/ocActiveQuestions.html
@@ -1,0 +1,29 @@
+<div class="page-content">
+  <div class="single-head">
+    <h3 class="pull-left"><i class="fa fa-table purple"></i>Active questions in <span class="text-warning">{{vm.group.name}}</span></h3>
+    <div class="clearfix"></div>
+  </div>
+
+  <br/>
+
+  <div class="page-tables">
+    <div class="table-responsive">
+      <table cellpadding="0" cellspacing="0" border="0" id="data-table" width="100%" class="dataTable">
+        <tbody>
+          <tr ng-if="vm.questions.length==0">
+            <td>There are no active questions for this group.</td>
+          </tr>
+          <tr ng-repeat="question in vm.questions  | filter:{groupId:vm.groupId}">
+            <td>{{question.questionAsked}}</td>
+            <td>
+              <div class="pull-right">
+                <a ui-sref="answerQuestion({ questionId: question._id })"><button class="btn btn-primary">Answer</button></a>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="clearfix"></div>
+    </div>
+  </div>
+</div>

--- a/client/templates/directives/ocGroups.html
+++ b/client/templates/directives/ocGroups.html
@@ -22,6 +22,7 @@
             <td><a class="text-primary">{{group.name}}</a></td>
             <td>
               <div class="pull-right">
+                <a ui-sref="activeQuestions({ groupId: group._id })"><button class="btn btn-primary">Active Questions</button></a>
                 <oc-leave-group group-id="{{group._id}}"></oc-leave-group>
               </div>
             </td>

--- a/client/templates/routes/activeQuestions.html
+++ b/client/templates/routes/activeQuestions.html
@@ -1,0 +1,13 @@
+<div class="page-content" ng-controller="activeQuestionsCtrl as vm">
+  <div class="single-head">
+    <h1 class="pull-left text-primary"><i class="fa fa-credit-card red"></i> Questions</h1>
+    <div class="clearfix"></div>
+  </div>
+  
+  <div class="page-tables">
+    <div class="table-responsive">
+      <oc-active-questions group-id="{{vm.groupId}}"></oc-active-questions>
+      <div class="clearfix"></div>
+    </div>
+  </div>
+</div>

--- a/server/publish.js
+++ b/server/publish.js
@@ -92,8 +92,23 @@ Meteor.publish('activeQuestions', function () {
   }, {
     fields: {
       answer: false,
-      userId: false,
-      groupId: false
+      userId: false
+    }
+  });
+});
+
+Meteor.publish('joinedGroups', function () {
+  if(!this.userId)
+  {
+    return null;
+  }
+  return Groups.find({
+    _id: {
+      $in: Meteor.users.findOne({_id: this.userId}).groups
+    }
+  }, {
+    fields: {
+      name: true
     }
   });
 });


### PR DESCRIPTION
Add directive, route, and controllers for a view of active questions in a group.  Update joined
groups list to use new 'joinedGroups' publication. Add links to joined groups list to active
questions for each group.  Add groupId to activeQuestions publication.

Closes #123
