### PR TITLE
fix:  fix misspelling of correct

### DIFF
--- a/client/templates/directives/ocGroupSummary.html
+++ b/client/templates/directives/ocGroupSummary.html
@@ -8,7 +8,7 @@
                     <th>Student ID</th>
                     <th>Email</th>
                     <th>Attendance Rate</th>
-                    <th>Currect Rate</th>
+                    <th>Correct Rate</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Fix table header labeled 'Currect Rate' to say Correct Rate.
